### PR TITLE
Add some ssl support

### DIFF
--- a/bin/watch.js
+++ b/bin/watch.js
@@ -17,6 +17,7 @@ const nodeFetch = require('node-fetch');
 const keytar = require('keytar');
 const url = require('url');
 const inquirer = require('inquirer');
+const https = require('https');
 
 require('yargs')
   .command('watch [folder]', 'watch the folder', (yargs) => {
@@ -33,6 +34,12 @@ require('yargs')
         alias: 'r',
         describe: 'Webdav server url',
         type: 'string',
+      })
+      .option('ssl', {
+        alias: 's',
+        describe: 'Suppress ssl issues',
+        type: 'boolean',
+        default: false
       })
       .option('username', {
         alias: 'u',
@@ -85,7 +92,9 @@ require('yargs')
 
       logger.silly(`About to upload file ${chalk.cyan(remoteFilepath)} on remote server ${chalk.cyan(argv.remote)}`);
 
-      fetch(remoteFilepath, { body: fileContents })
+      const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+      const opts = argv.ssl ? { body: fileContents, agent: httpsAgent } : { body: fileContents };
+      fetch(remoteFilepath, opts)
         .then(() => {
           logger.info(`Successfully uploaded file ${chalk.green(remoteFilepath)}`);
           notifier.notify({

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chalk": "^2.3.1",
     "node-fetch": "^2.0.0",
     "keytar": "^4.1.0",
-    "inquirer": "^5.1.0"
+    "inquirer": "^5.1.0",
+    "https": "^1.0.0"
   }
 }


### PR DESCRIPTION
This PR adds some SSL support to make the CLI a little more secure :)

With Basic Authentication set on an HTTPS WebDav server like:  ```https://bla:bla@webdav.geo.com/bucket``` the following exception would be raised by the ```node-fetch``` module during file transfer.

__Error__

```
FetchError: request to https://bla:bla@webdav.geo.com/bucket/test.txt failed, reason: unable to verify the first certificate
    at ClientRequest.<anonymous> (/Users/bla/webdav-watch/node_modules/node-fetch/lib/index.js:1461:11)
    at ClientRequest.emit (events.js:200:13)
    at ClientRequest.EventEmitter.emit (domain.js:471:20)
    at TLSSocket.socketErrorListener (_http_client.js:410:9)
    at TLSSocket.emit (events.js:200:13)
    at TLSSocket.EventEmitter.emit (domain.js:471:20)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:9) {
  message: 'request to ' +
    'https://bla:bla@webdav.geo.com/bucket/test.txt failed, ' +
    'reason: unable to verify the first certificate',
  type: 'system',
  errno: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
  code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
}

```

This PR includes new proposed usage:

__Commands__
```shell
webdav-watch watch --folder ./music --s false --remote https://bla:bla@webdav.geo.com/bucket
```

OR

```shell
webdav-watch watch --folder ./music --ssl false --remote https://bla:bla@webdav.geo.com/bucket
```

AND

```shell
webdav-watch watch --folder ./music --s true --remote https://bla:bla@webdav.geo.com/bucket
```

OR

```shell
webdav-watch watch --folder ./music --ssl true --remote https://bla:bla@webdav.geo.com/bucket
```

__Command using config__
```shell
webdav-watch watch --c ./config.json
```


__Example Configs__
```js
{
    "remote": " https://bla:bla@webdav.geo.com/bucket",
    "folder": "./music",
    "ssl": false
}
```

```js
{
    "remote": " https://bla:bla@webdav.geo.com/bucket",
    "folder": "./music",
    "ssl": true
}
```